### PR TITLE
Fix missing ayat rendering on desktop

### DIFF
--- a/components/surah-detail.tsx
+++ b/components/surah-detail.tsx
@@ -65,7 +65,7 @@ const SurahDetail: React.FC<SurahDetailProps> = (surah) => {
   }, []);
 
   return (
-    <Card className="border-none sm:border overflow-hidden transition-all duration-300 bg-gradient-to-br from-primary/10 via-background to-primary/10 shadow-none sm:shadow-lg text-foreground rounded-b-[2rem] p-0">
+    <Card className="border-none sm:border transition-all duration-300 bg-gradient-to-br from-primary/10 via-background to-primary/10 shadow-none sm:shadow-lg text-foreground rounded-b-[2rem] p-0">
         <CardContent className="p-0">
           {/* pre bismillah */}
           {surah.preBismillah && (


### PR DESCRIPTION
Removed the overflow-hidden CSS class from the Card component in the Quran surah detail page. This class was preventing verses beyond the viewport height from being displayed on desktop screens, while working correctly on mobile.

The overflow-hidden was causing the content to be clipped, making verses like ayat 4 and beyond invisible on desktop browsers. Removing this class allows all verses to display properly across all screen sizes.